### PR TITLE
Add API Dynamics section

### DIFF
--- a/draft-trammell-taps-post-sockets.md
+++ b/draft-trammell-taps-post-sockets.md
@@ -544,7 +544,7 @@ architecture {{NEAT}} provides an example of how this can be done).
 A Transient represents a binding between a Carrier and the instance of
 the transport protocol stack that implements it. As an Association contains
 long-term state for communications between two endpoints, a Transient contains
-ephemeral state for a single transport protocol over a single Path at a given
+ephemeral state for a single transport protocol over a one or more Paths at a given
 point in time.
 
 A Carrier may be served by multiple Transients at once, e.g. when

--- a/draft-trammell-taps-post-sockets.md
+++ b/draft-trammell-taps-post-sockets.md
@@ -541,11 +541,11 @@ architecture {{NEAT}} provides an example of how this can be done).
 
 ## Transient
 
-A Transient represents a binding between a Carrier and the instance of
-the transport protocol stack that implements it. As an Association contains
+A Transient represents a binding between a Carrier and the instance of the
+transport protocol stack that implements it. As an Association contains
 long-term state for communications between two endpoints, a Transient contains
-ephemeral state for a single transport protocol over a one or more Paths at a given
-point in time.
+ephemeral state for a single transport protocol over a one or more Paths at a
+given point in time.
 
 A Carrier may be served by multiple Transients at once, e.g. when
 implementing multipath communication such that the separate paths are exposed to

--- a/draft-trammell-taps-post-sockets.md
+++ b/draft-trammell-taps-post-sockets.md
@@ -279,19 +279,16 @@ corresponding Carrier at the remote endpoint, though not necessarily
 reliably or in order, depending on Message properties and the underlying
 transport protocol stack.
 
-A Carrier that is backed by current transport protocol stack state
-(such as a TCP connection; see {{transient}}) is said to be "active": messages
-can be sent and received over it. A Carrier can also be "dormant":
-there is long-term state associated with it (via the underlying Association;
-see {{association}}), and it may be able to reactivated, but messages cannot
-be sent and received immediately.
-
-Carriers may actively be made dormant and disposed of, or may become dormant
-because the underlying transport protocol stack determines that an underlying
-connection has been lost and there is insufficient state in the Association to
-re-establish it (e.g., in the case of a server-side Carrier where the client's
-address has changed unexpectedly). Passive close can be handled by the
-application via an event on the carrier.
+A Carrier that is backed by current transport protocol stack state (such as a
+TCP connection; see {{transient}}) is said to be "active": messages can be sent
+and received over it. A Carrier can also be "dormant": there is long-term state
+associated with it (via the underlying Association; see {{association}}), and it
+may be able to reactivated, but messages cannot be sent and received
+immediately. Carriers become dormant when the underlying transport protocol
+stack determines that an underlying connection has been lost and there is
+insufficient state in the Association to re-establish it (e.g., in the case of a
+server-side Carrier where the client's address has changed unexpectedly).
+Passive close can be handled by the application via an event on the carrier.
 
 If supported by the underlying transport protocol stack, a Carrier may be
 forked: creating a new Carrier associated with a new Carrier at the same remote

--- a/draft-trammell-taps-post-sockets.md
+++ b/draft-trammell-taps-post-sockets.md
@@ -880,7 +880,21 @@ Each Carrier has a .Send() method, by which Messages can be sent with given
 properties, and a .Ready() method, which supplies a callback for reading
 Messages from the remote side. .Send() is not available on Sinks, and .Ready()
 is not available on Sources. Carriers also provide .OnSent(), .OnAcked(), and
-.OnExpired() calls for binding default send event handlers to the Carrier.
+.OnExpired() calls for binding default send event handlers to the Carrier, and
+.OnClosed() for handling passive close notifications.
+
+~~~~~~~
+                                  +---------[incoming]-----------+
+                                  |         [Message ]           V
+[outgoing] ---> .Send() --->  [Carrier] <---- .Ready() <---- [Receiver]
+[Message ]                        |
+                                  +--- .OnSent()
+                                  +--- .OnAcked()
+                                  +--- .OnExpired()
+                                  +--- .OnClosed()       
+~~~~~~~
+{: #fig-message-lc title="Sending and Receiving Messages and Events"}
+
 
 \[EDITOR'S NOTE (bht) on the text below: Parameters, as above, PolicyContext, and
 a Configuration are the same thing, as in

--- a/draft-trammell-taps-post-sockets.md
+++ b/draft-trammell-taps-post-sockets.md
@@ -769,10 +769,6 @@ func receiveMulticast() {
 }
 ~~~~~~~~
 
-### Streams as Incomplete Messages
-
-[EDITOR'S NOTE: write me]
-
 ### Association Bootstrapping
 
 Here, we show how Association state may be initialized without a carrier.


### PR DESCRIPTION
Addessing #3 and #5, on review I think I kind of like an introduction by example, followed by a more formal description of the various "paths" through the API. I've started a new API Dynamics section to see if this approach makes sense.

This is not at all ready for merge, but I wanted to go ahead and see if people liked this approach before fleshing this out, or did we want to do something more formal by listing entry points and class methods and whatnot. For discussion on today's call, for those awake in time to see this PR.